### PR TITLE
fix(syndesis-integration-runtime): Correct pipeline library repository

### DIFF
--- a/configuration/jobs/syndesis-integration-runtime/config.xml
+++ b/configuration/jobs/syndesis-integration-runtime/config.xml
@@ -14,7 +14,7 @@
                             <checkoutCredentialsId>SAME</checkoutCredentialsId>
                             <scanCredentialsId>github</scanCredentialsId>
                             <repoOwner>syndesisio</repoOwner>
-                            <repository>syndesis-integration-runtime</repository>
+                            <repository>syndesis-pipeline-library</repository>
                             <includes>*</includes>
                             <excludes></excludes>
                             <buildOriginBranch>true</buildOriginBranch>


### PR DESCRIPTION
Shared pipeline library was pointing to its own git repo rather than syndesis-pipeline-library.