### PR TITLE
chore: Limits the build history to 14 days

### DIFF
--- a/configuration/jobs/connectors/config.xml
+++ b/configuration/jobs/connectors/config.xml
@@ -56,7 +56,7 @@
             class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy"
             plugin="cloudbees-folder@6.0.3">
         <pruneDeadBranches>true</pruneDeadBranches>
-        <daysToKeep>0</daysToKeep>
+        <daysToKeep>14</daysToKeep>
         <numToKeep>0</numToKeep>
     </orphanedItemStrategy>
     <triggers/>

--- a/configuration/jobs/syndesis-datamapper/config.xml
+++ b/configuration/jobs/syndesis-datamapper/config.xml
@@ -55,7 +55,7 @@
             class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy"
             plugin="cloudbees-folder@6.0.3">
         <pruneDeadBranches>true</pruneDeadBranches>
-        <daysToKeep>0</daysToKeep>
+        <daysToKeep>14</daysToKeep>
         <numToKeep>0</numToKeep>
     </orphanedItemStrategy>
     <triggers/>

--- a/configuration/jobs/syndesis-e2e-tests/config.xml
+++ b/configuration/jobs/syndesis-e2e-tests/config.xml
@@ -56,7 +56,7 @@
             class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy"
             plugin="cloudbees-folder@6.0.3">
         <pruneDeadBranches>true</pruneDeadBranches>
-        <daysToKeep>0</daysToKeep>
+        <daysToKeep>14</daysToKeep>
         <numToKeep>0</numToKeep>
     </orphanedItemStrategy>
     <triggers/>

--- a/configuration/jobs/syndesis-integration-runtime/config.xml
+++ b/configuration/jobs/syndesis-integration-runtime/config.xml
@@ -56,7 +56,7 @@
             class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy"
             plugin="cloudbees-folder@6.0.3">
         <pruneDeadBranches>true</pruneDeadBranches>
-        <daysToKeep>0</daysToKeep>
+        <daysToKeep>14</daysToKeep>
         <numToKeep>0</numToKeep>
     </orphanedItemStrategy>
     <triggers/>

--- a/configuration/jobs/syndesis-pipeline-library/config.xml
+++ b/configuration/jobs/syndesis-pipeline-library/config.xml
@@ -56,7 +56,7 @@
           class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy"
           plugin="cloudbees-folder@6.0.3">
     <pruneDeadBranches>true</pruneDeadBranches>
-    <daysToKeep>0</daysToKeep>
+    <daysToKeep>14</daysToKeep>
     <numToKeep>0</numToKeep>
   </orphanedItemStrategy>
   <triggers/>

--- a/configuration/jobs/syndesis-rest/config.xml
+++ b/configuration/jobs/syndesis-rest/config.xml
@@ -56,7 +56,7 @@
             class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy"
             plugin="cloudbees-folder@6.0.3">
         <pruneDeadBranches>true</pruneDeadBranches>
-        <daysToKeep>0</daysToKeep>
+        <daysToKeep>14</daysToKeep>
         <numToKeep>0</numToKeep>
     </orphanedItemStrategy>
     <triggers/>

--- a/configuration/jobs/syndesis-system-tests/config.xml
+++ b/configuration/jobs/syndesis-system-tests/config.xml
@@ -56,7 +56,7 @@
           class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy"
           plugin="cloudbees-folder@6.0.3">
     <pruneDeadBranches>true</pruneDeadBranches>
-    <daysToKeep>0</daysToKeep>
+    <daysToKeep>14</daysToKeep>
     <numToKeep>0</numToKeep>
   </orphanedItemStrategy>
   <triggers/>

--- a/configuration/jobs/syndesis-templates/config.xml
+++ b/configuration/jobs/syndesis-templates/config.xml
@@ -56,7 +56,7 @@
           class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy"
           plugin="cloudbees-folder@6.0.3">
     <pruneDeadBranches>true</pruneDeadBranches>
-    <daysToKeep>0</daysToKeep>
+    <daysToKeep>14</daysToKeep>
     <numToKeep>0</numToKeep>
   </orphanedItemStrategy>
   <triggers/>


### PR DESCRIPTION
We're running out of disk space on Jenkins, this limits build history to
14 days for all configured jobs.